### PR TITLE
feat: write post-process-data.json to postprocess/ directory

### DIFF
--- a/pytorch-post-process
+++ b/pytorch-post-process
@@ -113,7 +113,7 @@ def main():
         metric_file_name = finish_samples()
         period['metric-files'].append(metric_file_name)
         iter_sample['periods'].append(period)
-        f = open('post-process-data.json', 'w')
+        f = open('postprocess/post-process-data.json', 'w')
         f.write(json.dumps(iter_sample))
         f.close
 


### PR DESCRIPTION
## Summary
- Write post-process-data.json to the postprocess/ subdirectory instead of the sample root directory
- Part of the Phase 2 migration for PERFNFV-316 (dedicated postprocess/ directory for all post-processing artifacts)

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Depends on
- toolbox PR #117 (merged) — CDMMetrics output_dir
- rickshaw PR #826 (merged) — orchestration creates/cleans postprocess/

🤖 Generated with [Claude Code](https://claude.com/claude-code)